### PR TITLE
Added simple tests, tox and updated setup.py

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Check http://editorconfig.org for more information
+# This is the main config file for this project:
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[.{md, rst, in}]
+indent_style = ignore
+indent_size = ignore

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -2,7 +2,8 @@
 """
 Dictator is a tiny library for Robots™ to work with Redis as a Dict.
 
-Dictator handles Redis command to make work with database as a dict-like object.
+Dictator handles Redis command to make work with
+database as a dict-like object.
 
 .. codeauthor:: Andrey Maksimov <meamka@ya.ru>
 
@@ -25,6 +26,7 @@ Usage example:
 import logging
 
 import redis
+import six
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +158,8 @@ class Dictator(object):
         self.__setitem__(key, value)
 
     def get(self, key, default=None):
-        """Return the value at key ``key``, or default value ``default`` which is None by default.
+        """Return the value at key ``key``, or default value ``default``
+        which is None by default.
 
         >>> dc = Dictator()
         >>> dc['l0'] = [1, 2, 3, 4]
@@ -189,7 +192,8 @@ class Dictator(object):
         self._redis.flushdb()
 
     def pop(self, key, default=None):
-        """Remove and return the last item of the list ``key``. If key doesn't exists it return ``default``.
+        """Remove and return the last item of the list ``key``.
+        If key doesn't exists it return ``default``.
 
         >>> dc = Dictator()
         >>> dc['l0'] = [1, 2, 3, 4]
@@ -210,7 +214,8 @@ class Dictator(object):
         return value
 
     def keys(self, pattern=None):
-        """Returns a list of keys matching ``pattern``. By default return all keys.
+        """Returns a list of keys matching ``pattern``.
+        By default return all keys.
 
         >>> dc = Dictator()
         >>> dc['l0'] = [1, 2, 3, 4]
@@ -316,9 +321,12 @@ class Dictator(object):
             yield key, self.get(key)
 
     def update(self, other=None, **kwargs):
-        """D.update([other, ]**kwargs) -> None.  Update D From dict/iterable ``other`` and ``kwargs``.
-        If ``other`` present and has a .keys() method, does:     for k in other: D[k] = other[k]
-        If ``other`` present and lacks .keys() method, does:     for (k, v) in other: D[k] = v
+        """D.update([other, ]**kwargs) -> None.
+        Update D From dict/iterable ``other`` and ``kwargs``.
+        If ``other`` present and has a .keys() method, does:
+            for k in other: D[k] = other[k]
+        If ``other`` present and lacks .keys() method, does:
+            for (k, v) in other: D[k] = v
         In either case, this is followed by: for k in kwargs: D[k] = kwargs[k]
 
         >>> dc = Dictator()
@@ -343,5 +351,5 @@ class Dictator(object):
                     self.set(key, value)
 
         if kwargs:
-            for key, value in kwargs.iteritems():
+            for key, value in six.iteritems(kwargs):
                 self.set(key, value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,42 @@
 from setuptools import setup, find_packages
 
-setup(
-    name='dictator',
-    version='0.1.1',
-    packages=find_packages(),
-    url='https://github.com/amka/dictator',
-    license='MIT',
-    author='andrey.maksimov',
-    author_email='meamka@ya.ru',
-    description='Dictator is a tiny library for Robots to work with Redis as a Dict.',
-    install_requires=['redis'],
-)
+if __name__ == "__main__":
+    setup(
+        name='dictator',
+        version='0.1.1',
+        packages=find_packages(),
+        url='https://github.com/amka/dictator',
+        license='MIT',
+        author='andrey.maksimov',
+        author_email='meamka@ya.ru',
+        description=(
+            'Dictator is a tiny library for Robots'
+            'to work with Redis as a Dict.'
+        ),
+        install_requires=[
+            'redis',
+            'six',
+        ],
+        setup_requires=[
+            'pytest-runner',
+        ],
+        tests_require=[
+            'pytest',
+        ],
+        zip_safe=False,
+        include_package_data=True,
+        classifiers=[
+            'Development Status :: 4 - Beta',
+            'Environment :: Web Environment',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: BSD License',
+            'Operating System :: OS Independent',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Topic :: Internet :: WWW/HTTP',
+            'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+            'Topic :: Software Development',
+            'Topic :: Software Development :: Libraries :: Python Modules',
+        ],
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import pytest
+
+from dictator import Dictator
+
+
+@pytest.fixture
+def dictator_inst():
+    return Dictator(decode_responses=True)
+
+
+@pytest.fixture(params=[
+    'some-test-value',
+    ['1', '2', '3'],
+    {'a': 'A', 'b': 'B'},
+])
+def key_value(request):
+    key = 'some-test-key'
+    value = request.param
+    dc = dictator_inst()
+    dc[key] = value
+
+    yield key, value
+    del dc[key]

--- a/tests/test_contains.py
+++ b/tests/test_contains.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+
+def test_contains_normal(dictator_inst, key_value):
+    key, _ = key_value
+    assert key in dictator_inst
+
+
+def test_contains_missing(dictator_inst):
+    assert 'test-missing' not in dictator_inst

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+
+def test_get_item_normal(dictator_inst, key_value):
+    key, value = key_value
+    assert dictator_inst[key] == value
+
+
+def test_get_item_method(dictator_inst, key_value):
+    key, value = key_value
+    assert dictator_inst.get(key) == value
+
+
+def test_get_item_empty(dictator_inst):
+    test_default = 'test-default'
+    assert dictator_inst.get(
+        'does-not-exist', test_default
+    ) == test_default

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+
+def test_init_normal(dictator_inst):
+    assert dictator_inst.host == 'localhost'
+    assert dictator_inst.port == 6379
+    assert dictator_inst.db == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, py35
+
+[testenv]
+recreate = False
+deps =
+    pytest
+commands =
+    py.test -rw .


### PR DESCRIPTION
Sorry, that it took me so long to answer. And sorry for such small amount of tests. But, it is something!

Changes:
1. Updated setup.py to contain classifiers, test dependencies and other useful stuff
2. Added pytest as a test runner and simple tests
3. Refactored `dictator` itself to be python3 compat, also fixed line-width
4. Added tox.ini to run tests on python27, python35
5. Added .editorconfig to fix file styles

Closes #1, closes #2

Output:

> (dictator) [21:58:13] sobolev :: MacBook-Pro-Nikita  ➜  Documents/github/dictator ‹master*› » tox                                                           1 ↵
> GLOB sdist-make: /Users/sobolev/Documents/github/dictator/setup.py
> py27 inst-nodeps: /Users/sobolev/Documents/github/dictator/.tox/dist/dictator-0.1.1.zip
> py27 installed: dictator==0.1.1,py==1.4.31,pytest==3.0.3,redis==2.10.5,six==1.10.0
> py27 runtests: PYTHONHASHSEED='3816046555'
> py27 runtests: commands[0] | py.test -rw .
> ============================= test session starts ==============================
> platform darwin -- Python 2.7.11, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
> rootdir: /Users/sobolev/Documents/github/dictator, inifile: 
> collected 12 items 
> 
> tests/test_contains.py ....
> tests/test_getitem.py .......
> tests/test_init.py .
> 
> ========================== 12 passed in 0.05 seconds ===========================
> py35 inst-nodeps: /Users/sobolev/Documents/github/dictator/.tox/dist/dictator-0.1.1.zip
> py35 installed: dictator==0.1.1,py==1.4.31,pytest==3.0.3,redis==2.10.5,six==1.10.0
> py35 runtests: PYTHONHASHSEED='3816046555'
> py35 runtests: commands[0] | py.test -rw .
> ============================= test session starts ==============================
> platform darwin -- Python 3.5.1, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
> rootdir: /Users/sobolev/Documents/github/dictator, inifile: 
> collected 12 items 
> 
> tests/test_contains.py ....
> tests/test_getitem.py .......
> tests/test_init.py .
> 
> ========================== 12 passed in 0.07 seconds ===========================
> ___________________________________ summary ____________________________________
>   py27: commands succeeded
>   py35: commands succeeded
>   congratulations :)

What do you think?
