### PR TITLE
Updating README and package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For the moment it handles not all features of Python Dict but basics:
     * `.itervalues()`
     * `.iteritems()`
 
-* `lock(name, timeout=None, sleep=0.1, blocking_timeout=None, lock_class=None, thread_local=True)` will return `redis-py`'s `Lock` object.
+* `.lock(name, timeout=None, sleep=0.1, blocking_timeout=None, lock_class=None, thread_local=True)` will return `redis-py`'s `Lock` object.
 
     * Manually acquire-release:
     ```python

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ For the moment it handles not all features of Python Dict but basics:
 * `.lock(name, timeout=None, sleep=0.1, blocking_timeout=None, lock_class=None, thread_local=True)` will return `redis-py`'s `Lock` object.
 
     * Manually acquire-release:
+    
     ```python
         >>> lock = dc.lock('foo')
         >>> lock.acquire()
@@ -111,6 +112,7 @@ For the moment it handles not all features of Python Dict but basics:
     ```
 
     * With context manager:
+
     ```python
         >>> with dc.lock('foo'):
         >>>    print(dc.get('foo'))

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For the moment it handles not all features of Python Dict but basics:
 * `.items()`
 
     ```python
-    >>> dc.iterms()
+    >>> dc.items()
     [('Planets', ['Mercury', 'Venus', 'Earth'])]
     ```
     
@@ -97,5 +97,38 @@ For the moment it handles not all features of Python Dict but basics:
     * `.iterkeys()`
     * `.itervalues()`
     * `.iteritems()`
+
+* `lock(name, timeout=None, sleep=0.1, blocking_timeout=None, lock_class=None, thread_local=True)` will return `redis-py`'s `Lock` object.
+
+    * Manually acquire-release:
+    ```python
+        >>> lock = dc.lock('foo')
+        >>> lock.acquire()
+        >>> dc.get('foo')
+        '776bf70c6de811e799f6c4b301cdb05d'
+        >>> lock.release()
+        >>> dc.get('foo')
+    ```
+
+    * With context manager:
+    ```python
+        >>> with dc.lock('foo'):
+        >>>    print(dc.get('foo'))
+        '776bf70c6de811e799f6c4b301cdb05d'
+        >>> dc.get('foo'))
+    ```
+
+* a copy of a `Dictator` object will be Python's standard `dict`:
+
+    ```python
+        >>> from copy import copy, deepcopy
+        >>> d = dc.copy()
+        >>> d
+        {'Planets': ['Mercury', 'Venus', 'Earth']}
+        >>> type(d)
+        dict
+        >>> copy(dc) == deepcopy(dc) == dc.copy()
+        True
+    ```
     
 * and more 

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -155,7 +155,7 @@ class Dictator(object):
         :rtype: int
         """
         logger.debug('call __len__')
-        return len(self.keys())
+        return self._redis.dbsize()
 
     def copy(self):
         """Convert ``Dictator`` to standard ``dict`` object

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 if __name__ == "__main__":
     setup(
         name='dictator',
-        version='0.2.6',
+        version='0.3.0',
         packages=find_packages(),
         url='https://github.com/amka/dictator',
         license='MIT',


### PR DESCRIPTION
* Updated **README.md**:
    * added `.lock()` description with two examples (manual acquire-release and using context manager).
    * added `.copy()` description with examples showing returned value, returned value type and that `copy.copy(dc)`, `copy.deepcopy(dc)` and `dc.copy()` produce the same result.
    * minor fix in existing **README**.
* Upgraded version in `setup.py` file to **0.3.0** 
* Use `redis.dbsize()` for getting `__len__` of a `Dictator` object