### PR TITLE
Update to 0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ For the moment it handles not all features of Python Dict but basics:
     * `.itervalues()`
     * `.iteritems()`
 
-* `lock(name, timeout=None, sleep=0.1, blocking_timeout=None, lock_class=None, thread_local=True)` will return `redis-py`'s `Lock` object.
+* `.lock(name, timeout=None, sleep=0.1, blocking_timeout=None, lock_class=None, thread_local=True)` will return `redis-py`'s `Lock` object.
 
     * Manually acquire-release:
     ```python

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ For the moment it handles not all features of Python Dict but basics:
 * `.lock(name, timeout=None, sleep=0.1, blocking_timeout=None, lock_class=None, thread_local=True)` will return `redis-py`'s `Lock` object.
 
     * Manually acquire-release:
+    
     ```python
         >>> lock = dc.lock('foo')
         >>> lock.acquire()
@@ -111,6 +112,7 @@ For the moment it handles not all features of Python Dict but basics:
     ```
 
     * With context manager:
+
     ```python
         >>> with dc.lock('foo'):
         >>>    print(dc.get('foo'))

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For the moment it handles not all features of Python Dict but basics:
 * `.items()`
 
     ```python
-    >>> dc.iterms()
+    >>> dc.items()
     [('Planets', ['Mercury', 'Venus', 'Earth'])]
     ```
     
@@ -97,5 +97,38 @@ For the moment it handles not all features of Python Dict but basics:
     * `.iterkeys()`
     * `.itervalues()`
     * `.iteritems()`
+
+* `lock(name, timeout=None, sleep=0.1, blocking_timeout=None, lock_class=None, thread_local=True)` will return `redis-py`'s `Lock` object.
+
+    * Manually acquire-release:
+    ```python
+        >>> lock = dc.lock('foo')
+        >>> lock.acquire()
+        >>> dc.get('foo')
+        '776bf70c6de811e799f6c4b301cdb05d'
+        >>> lock.release()
+        >>> dc.get('foo')
+    ```
+
+    * With context manager:
+    ```python
+        >>> with dc.lock('foo'):
+        >>>    print(dc.get('foo'))
+        '776bf70c6de811e799f6c4b301cdb05d'
+        >>> dc.get('foo'))
+    ```
+
+* a copy of a `Dictator` object will be Python's standard `dict`:
+
+    ```python
+        >>> from copy import copy, deepcopy
+        >>> d = dc.copy()
+        >>> d
+        {'Planets': ['Mercury', 'Venus', 'Earth']}
+        >>> type(d)
+        dict
+        >>> copy(dc) == deepcopy(dc) == dc.copy()
+        True
+    ```
     
 * and more 

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -155,7 +155,7 @@ class Dictator(object):
         :rtype: int
         """
         logger.debug('call __len__')
-        return len(self.keys())
+        return self._redis.dbsize()
 
     def copy(self):
         """Convert ``Dictator`` to standard ``dict`` object

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -157,6 +157,31 @@ class Dictator(object):
         logger.debug('call __len__')
         return len(self.keys())
 
+    def copy(self):
+        """Convert ``Dictator`` to standard ``dict`` object
+
+        >>> dc = Dictator()
+        >>> dc['l0'] = [1, 2]
+        >>> dc['1'] = 'abc'
+        >>> d = dc.copy()
+        >>> type(d)
+        dict
+        >>> d
+        {'l0': ['1', '2'], '1': 'abc'}
+        >>> dc.clear()
+
+        :return: Python's dict object
+        :rtype: dict
+        """
+        logger.debug('call to_dict')
+        return {key: self.get(key) for key in self.keys()}
+
+    def __deepcopy__(self, memo):
+        """Convert ``Dictator`` to standard ``dict`` object
+        by simply calling ``copy()`` method.
+        """
+        return self.copy()
+
     def set(self, key, value):
         """Set the value at key ``key`` to ``value``
 
@@ -358,25 +383,6 @@ class Dictator(object):
         for key in self._redis.scan_iter(match=match, count=count):
             yield key, self.get(key)
 
-    def to_dict(self):
-        """Convert ``Dictator`` to standard ``dict`` object
-
-        >>> dc = Dictator()
-        >>> dc['l0'] = [1, 2]
-        >>> dc['1'] = 'abc'
-        >>> d = dc.to_dict()
-        >>> type(d)
-        dict
-        >>> d
-        {'l0': ['1', '2'], '1': 'abc'}
-        >>> dc.clear()
-
-        :return: Python's dict object
-        :rtype: dict
-        """
-        logger.debug('call to_dict')
-        return {key: self.get(key) for key in self.keys()}
-
     def update(self, other=None, **kwargs):
         """D.update([other, ]**kwargs) -> None.
         Update D From dict/iterable ``other`` and ``kwargs``.
@@ -439,3 +445,5 @@ class Dictator(object):
         """
         logger.debug('call lock %s', name)
         return self._redis.lock(name, *args, **kwargs)
+
+    __copy__ = copy

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -235,8 +235,6 @@ class Dictator(object):
         """
         logger.debug('call pop %s', key)
         value = self.get(key)
-        if not value:
-            raise KeyError(key)
         self._redis.delete(key)
         return value or default
 

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -368,13 +368,13 @@ class Dictator(object):
         >>> type(d)
         dict
         >>> d
-        {'l0': ['1', '2', '1': 'abc'}
+        {'l0': ['1', '2'], '1': 'abc'}
         >>> dc.clear()
 
         :return: Python's dict object
         :rtype: dict
         """
-        logger.debug('call items')
+        logger.debug('call to_dict')
         return {key: self.get(key) for key in self.keys()}
 
     def update(self, other=None, **kwargs):

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -439,4 +439,3 @@ class Dictator(object):
         """
         logger.debug('call lock %s', name)
         return self._redis.lock(name, *args, **kwargs)
-

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -234,9 +234,11 @@ class Dictator(object):
         :rtype: Any
         """
         logger.debug('call pop %s', key)
-        value = self.get(key, default)
+        value = self.get(key)
+        if not value:
+            raise KeyError(key)
         self._redis.delete(key)
-        return value
+        return value or default
 
     def keys(self, pattern=None):
         """Returns a list of keys matching ``pattern``.

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -70,6 +70,11 @@ class Dictator(object):
         :return: value of item with given name
         """
         logger.debug('call __getattr__ %s', item)
+
+        # Check whether item exists inside Redis storage or not.
+        if not self.__contains__(item):
+            raise KeyError(item)
+
         key_type = self._redis.type(item)
 
         # Python3 compatibility
@@ -181,10 +186,15 @@ class Dictator(object):
         :type default: Any
         :return: value of given key
         """
-        value = self.__getitem__(key) or default
+        try:
+            value = self.__getitem__(key)
+        except KeyError:
+            value = None
+
+        # Py3 Redis compatibiility
         if isinstance(value, bytes):
             value = value.decode()
-        return value
+        return value or default
 
     def clear(self):
         """Remove all items in current db.

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -75,7 +75,7 @@ class Dictator(object):
         # Python3 compatibility
         if isinstance(key_type, bytes):
             key_type = key_type.decode()
-        
+
         logger.debug('trying to get item %s of type %s', item, key_type)
 
         if key_type == 'hash':

--- a/dictator/__init__.py
+++ b/dictator/__init__.py
@@ -75,6 +75,8 @@ class Dictator(object):
         # Python3 compatibility
         if isinstance(key_type, bytes):
             key_type = key_type.decode()
+        
+        logger.debug('trying to get item %s of type %s', item, key_type)
 
         if key_type == 'hash':
             return self._redis.hgetall(item)
@@ -125,6 +127,7 @@ class Dictator(object):
         :return: True if exists or False in other case
         :rtype: bool
         """
+        logger.debug('call __contains__ %s', item)
         return self._redis.exists(item)
 
     def __len__(self):
@@ -143,6 +146,7 @@ class Dictator(object):
         :return: number of items in db
         :rtype: int
         """
+        logger.debug('call __len__')
         return len(self.keys())
 
     def set(self, key, value):
@@ -182,6 +186,8 @@ class Dictator(object):
         :return: value of given key
         """
         value = self.__getitem__(key) or default
+
+        # Py3 Redis compatibiility
         if isinstance(value, bytes):
             value = value.decode()
         return value
@@ -198,6 +204,7 @@ class Dictator(object):
         0
 
         """
+        logger.debug('call clear')
         self._redis.flushdb()
 
     def pop(self, key, default=None):
@@ -218,6 +225,7 @@ class Dictator(object):
         :return: value associated with given key or None or ``default``
         :rtype: Any
         """
+        logger.debug('call pop %s', key)
         value = self.get(key, default)
         self._redis.delete(key)
         return value
@@ -240,6 +248,7 @@ class Dictator(object):
         :return: list of keys in db
         :rtype: list of str
         """
+        logger.debug('call pop %s', pattern)
         if pattern is None:
             pattern = '*'
 
@@ -256,6 +265,7 @@ class Dictator(object):
 
         :return: list of tuple
         """
+        logger.debug('call items')
         return [(key, self.get(key)) for key in self.keys()]
 
     def values(self):
@@ -271,6 +281,7 @@ class Dictator(object):
 
         :return:
         """
+        logger.debug('call values')
         return [self.get(key) for key in self.keys()]
 
     def iterkeys(self, match=None, count=1):
@@ -296,6 +307,7 @@ class Dictator(object):
         :return: iterator over key.
         :return: iterator
         """
+        logger.debug('call iterkeys %s', match)
         if match is None:
             match = '*'
         for key in self._redis.scan_iter(match=match, count=count):
@@ -324,6 +336,7 @@ class Dictator(object):
         :return: iterator over key, value pairs.
         :return: iterator
         """
+        logger.debug('call iteritems %s', match)
         if match is None:
             match = '*'
         for key in self._redis.scan_iter(match=match, count=count):
@@ -351,6 +364,7 @@ class Dictator(object):
         :param other: dict/iterable with .keys() function.
         :param kwargs: key/value pairs
         """
+        logger.debug('call update %s', other)
         if other:
             if hasattr(other, 'keys'):
                 for key in other.keys():

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 if __name__ == "__main__":
     setup(
         name='dictator',
-        version='0.2.6',
+        version='0.3.0',
         packages=find_packages(),
         url='https://github.com/amka/dictator',
         license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 if __name__ == "__main__":
     setup(
         name='dictator',
-        version='0.2.3',
+        version='0.2.4',
         packages=find_packages(),
         url='https://github.com/amka/dictator',
         license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 if __name__ == "__main__":
     setup(
         name='dictator',
-        version='0.2.2',
+        version='0.2.5',
         packages=find_packages(),
         url='https://github.com/amka/dictator',
         license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 if __name__ == "__main__":
     setup(
         name='dictator',
-        version='0.2.5',
+        version='0.2.6',
         packages=find_packages(),
         url='https://github.com/amka/dictator',
         license='MIT',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 if __name__ == "__main__":
     setup(
         name='dictator',
-        version='0.2.2',
+        version='0.2.3',
         packages=find_packages(),
         url='https://github.com/amka/dictator',
         license='MIT',

--- a/tests/test_getitem.py
+++ b/tests/test_getitem.py
@@ -1,17 +1,30 @@
 # coding: utf-8
+import pytest
 
 
-def test_get_item_normal(dictator_inst, key_value):
+def test_getitem_nonexist(dictator_inst, key_value):
+    non_exist_key = 'non_exist'
+    with pytest.raises(KeyError) as exc_info:
+        _ = dictator_inst[non_exist_key]
+    assert non_exist_key in str(exc_info)
+
+
+def test_getitem_normal(dictator_inst, key_value):
     key, value = key_value
     assert dictator_inst[key] == value
 
 
-def test_get_item_method(dictator_inst, key_value):
+def test_get_nonexist(dictator_inst, key_value):
+    non_exist_key = 'non_exist'
+    assert dictator_inst.get(non_exist_key) == None
+
+
+def test_get_method(dictator_inst, key_value):
     key, value = key_value
     assert dictator_inst.get(key) == value
 
 
-def test_get_item_empty(dictator_inst):
+def test_get_empty(dictator_inst):
     test_default = 'test-default'
     assert dictator_inst.get(
         'does-not-exist', test_default


### PR DESCRIPTION
### Things we added:
* `.lock()` – to create and return `redis.lock.Lock` object for current connection to Redis
* `.copy()` – return dict object made from Dictator'ss data
* raise `KeyError` if key you are trying to get doesn't exist in Redis.
* more logging calls for better debug.

### Things we improved:
* Readme typos and deprecated methods.
