### PR TITLE
Add support for all redis-py's redis.Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ For the moment it handles not all features of Python Dict but basics:
     >>> dc.items()
     [('Planets', ['Mercury', 'Venus', 'Earth'])]
     ```
+
+* `.len()`
+
+    ```python
+    >>> len(dc)
+    1
+    ```
     
 * also it supports iteration via generator object:
 
@@ -96,39 +103,18 @@ For the moment it handles not all features of Python Dict but basics:
     * `.itervalues()`
     * `.iteritems()`
 
-* `.lock(name, timeout=None, sleep=0.1, blocking_timeout=None, lock_class=None, thread_local=True)` will return `redis-py`'s `Lock` object.
-
-    * Manually acquire-release:
-    
-    ```python
-        >>> lock = dc.lock('foo')
-        >>> lock.acquire()
-        >>> dc.get('foo')
-        '776bf70c6de811e799f6c4b301cdb05d'
-        >>> lock.release()
-        >>> dc.get('foo')
-    ```
-
-    * With context manager:
-
-    ```python
-        >>> with dc.lock('foo'):
-        >>>    print(dc.get('foo'))
-        '776bf70c6de811e799f6c4b301cdb05d'
-        >>> dc.get('foo'))
-    ```
-
 * a copy of a `Dictator` object will be Python's standard `dict`:
 
     ```python
-        >>> from copy import copy, deepcopy
-        >>> d = dc.copy()
-        >>> d
-        {'Planets': ['Mercury', 'Venus', 'Earth']}
-        >>> type(d)
-        dict
-        >>> copy(dc) == deepcopy(dc) == dc.copy()
-        True
+    >>> from copy import copy, deepcopy
+    >>> d = dc.copy()
+    >>> d
+    {'Planets': ['Mercury', 'Venus', 'Earth']}
+    >>> type(d)
+    dict
+    >>> copy(dc) == deepcopy(dc) == dc.copy()
+    True
     ```
-    
-* and more 
+
+* plus all methods of [redis-py](https://redis-py.readthedocs.io/en/latest/#redis.Redis) `Redis` instance 
+can be applied to an instance of `Dictator`


### PR DESCRIPTION
Now all `redis-py` method can be applied to `Dictator`'s instance by using `__getattr__` method.